### PR TITLE
상점 상세조회 API 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+.env
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/Enterprise.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/Enterprise.java
@@ -1,0 +1,46 @@
+package com.univ.sohwakhaeng.enterprise;
+
+import com.univ.sohwakhaeng.product.Product;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Enterprise {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "enterprise_id")
+    private Long id;
+
+    @Column(name = "enterprise_imageUrl")
+    private String imageUrl;
+
+    @Column(name = "enterprise_name")
+    private String name;
+
+    private String description;
+
+    private Double star;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private String address;
+
+    @OneToMany(mappedBy = "enterprise", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Product> products;
+
+}

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/api/EnterpriseController.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/api/EnterpriseController.java
@@ -1,0 +1,26 @@
+package com.univ.sohwakhaeng.enterprise.api;
+
+import com.univ.sohwakhaeng.enterprise.api.dto.EnterpriseDto;
+import com.univ.sohwakhaeng.enterprise.exception.EnterpriseNotFoundException;
+import com.univ.sohwakhaeng.enterprise.service.EnterpriseService;
+import com.univ.sohwakhaeng.global.common.dto.BaseResponse;
+import com.univ.sohwakhaeng.global.common.exception.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class EnterpriseController {
+
+    private final EnterpriseService enterPriseService;
+
+    @GetMapping("/api/enterprises/{enterPriseId}")
+    public BaseResponse<EnterpriseDto> getEnterpriseDetails(@PathVariable Long enterPriseId) throws EnterpriseNotFoundException {
+        return BaseResponse.success(
+                SuccessCode.GET_ENTERPRISE_DETAILS, enterPriseService.getEnterpriseDetails(enterPriseId));
+    }
+}

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseDto.java
@@ -1,0 +1,54 @@
+package com.univ.sohwakhaeng.enterprise.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.univ.sohwakhaeng.enterprise.Enterprise;
+import com.univ.sohwakhaeng.product.api.dto.ProductDto;
+import java.util.List;
+
+public record EnterpriseDto(
+        @JsonProperty("enterprise_id")
+        Long id,
+
+        @JsonProperty("enterprise_image_url")
+        String imageUrl,
+
+        @JsonProperty("enterprise_name")
+        String name,
+
+        @JsonProperty("description")
+        String description,
+
+        @JsonProperty("star")
+        Double star,
+
+        @JsonProperty("latitude")
+        Double latitude,
+
+        @JsonProperty("longitude")
+        Double longitude,
+
+        @JsonProperty("address")
+        String address,
+
+        @JsonProperty("products")
+        List<ProductDto> products
+) {
+
+    public static EnterpriseDto fromEntity(Enterprise enterprise) {
+        return new EnterpriseDto(
+                enterprise.getId(),
+                enterprise.getImageUrl(),
+                enterprise.getName(),
+                enterprise.getDescription(),
+                enterprise.getStar(),
+                enterprise.getLatitude(),
+                enterprise.getLongitude(),
+                enterprise.getAddress(),
+                enterprise.getProducts().stream()
+                        .map(ProductDto::fromEntity)
+                        .toList()
+        );
+    }
+
+}
+

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/exception/EnterpriseNotFoundException.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/exception/EnterpriseNotFoundException.java
@@ -1,0 +1,10 @@
+package com.univ.sohwakhaeng.enterprise.exception;
+
+import lombok.Getter;
+
+@Getter
+public class EnterpriseNotFoundException extends Exception {
+    public EnterpriseNotFoundException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/repository/EnterpriseRepository.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/repository/EnterpriseRepository.java
@@ -1,0 +1,4 @@
+package com.univ.sohwakhaeng.enterprise.repository;
+
+public interface EnterpriseRepository {
+}

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/repository/EnterpriseRepository.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/repository/EnterpriseRepository.java
@@ -1,4 +1,7 @@
 package com.univ.sohwakhaeng.enterprise.repository;
 
-public interface EnterpriseRepository {
+import com.univ.sohwakhaeng.enterprise.Enterprise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EnterpriseRepository extends JpaRepository<Enterprise, Long> {
 }

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/service/EnterpriseService.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/service/EnterpriseService.java
@@ -1,0 +1,30 @@
+package com.univ.sohwakhaeng.enterprise.service;
+
+import com.univ.sohwakhaeng.enterprise.Enterprise;
+import com.univ.sohwakhaeng.enterprise.api.dto.EnterpriseDto;
+import com.univ.sohwakhaeng.enterprise.exception.EnterpriseNotFoundException;
+import com.univ.sohwakhaeng.enterprise.repository.EnterpriseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.univ.sohwakhaeng.global.common.exception.ErrorCode.ENTERPRISE_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class EnterpriseService {
+
+    private final EnterpriseRepository enterpriseRepository;
+
+    @Transactional(readOnly = true)
+    public EnterpriseDto getEnterpriseDetails(Long enterpriseId) throws EnterpriseNotFoundException {
+        Enterprise enterprise = findEnterpriseEntityById(enterpriseId);
+        return EnterpriseDto.fromEntity(enterprise);
+    }
+
+    private Enterprise findEnterpriseEntityById(Long id) throws EnterpriseNotFoundException {
+        return enterpriseRepository.findById(id)
+                .orElseThrow(() -> new EnterpriseNotFoundException(ENTERPRISE_NOT_FOUND.getMessage()));
+    }
+
+}

--- a/src/main/java/com/univ/sohwakhaeng/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/common/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
      * 404 NOT FOUND
      * */
     USER_NOT_FOUND(HttpStatus.NO_CONTENT, "해당 유저가 존재하지 않습니다"),
+    ENTERPRISE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가게가 존재하지 않습니다"),
     /**
      * 500 INTERNAL SERVER ERROR
      */

--- a/src/main/java/com/univ/sohwakhaeng/global/common/exception/SuccessCode.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/common/exception/SuccessCode.java
@@ -21,6 +21,9 @@ public enum SuccessCode {
     GET_ALL_BOARD(HttpStatus.OK, "전체 게시판 조회 성공"),
     POST_UPLOADED(HttpStatus.OK, "게시글 업로드 성공"),
     GET_MY_POSTS(HttpStatus.OK, "내가 쓴 글 조회 성공"),
+
+    // Enterprise 관련
+    GET_ENTERPRISE_DETAILS(HttpStatus.OK, "상점 상세 정보 조회 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/univ/sohwakhaeng/product/Product.java
+++ b/src/main/java/com/univ/sohwakhaeng/product/Product.java
@@ -1,0 +1,37 @@
+package com.univ.sohwakhaeng.product;
+
+import com.univ.sohwakhaeng.enterprise.Enterprise;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "enterprise_id")
+    private Enterprise enterprise;
+
+    @Column(name = "product_name")
+    private String name;
+
+    private String unit;
+
+    @Column(name = "product_price")
+    private Integer price;
+
+}

--- a/src/main/java/com/univ/sohwakhaeng/product/api/dto/ProductDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/product/api/dto/ProductDto.java
@@ -1,0 +1,33 @@
+package com.univ.sohwakhaeng.product.api.dto;
+
+import com.univ.sohwakhaeng.product.Product;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ProductDto(
+        @JsonProperty("product_id")
+        Long id,
+
+        @JsonProperty("enterprise_id")
+        Long enterpriseId,
+
+        @JsonProperty("product_name")
+        String name,
+
+        @JsonProperty("unit")
+        String unit,
+
+        @JsonProperty("product_price")
+        Integer price
+) {
+
+    public static ProductDto fromEntity(Product product) {
+        return new ProductDto(
+                product.getId(),
+                product.getEnterprise() != null ? product.getEnterprise().getId() : null,
+                product.getName(),
+                product.getUnit(),
+                product.getPrice()
+        );
+    }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,5 @@
+server:
+  port: 1234
 spring:
   application:
     name: sohwakhaeng
@@ -13,7 +15,7 @@ spring:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
# 🔖 개요

이슈번호 #6

상점 상세조회 API를 작성했습니다.

# 🖊️ 상세 설명
상점 id를 pathVariable로 전달하면 상세 정보를 반환합니다.
임의로 하나의 상점과 그 상점의 두 가지 상품을 저장하고 테스트했습니다.

추후 PM님께 Mock 데이터 받으면 DB에 저장할 수 있도록 하겠습니다.

특이사항은 JWT 없이 상점 상세조회 API에서 응답을 받을 수 있는 상태입니다.
@zzdh8님께서 구현해주신 인증 기능에서 filter쪽 확인 부탁드립니다!

# 📷 예시 or 스크린샷
postman으로 테스트했습니다.
```
{
    "statusCode": 200,
    "message": "상점 상세 정보 조회 성공",
    "data": {
        "enterprise_id": 1,
        "enterprise_image_url": "url",
        "enterprise_name": "미미네 채소가게",
        "description": "신선한 야채를 판매하고 있어요",
        "star": 4.5,
        "latitude": 0.1,
        "longitude": 0.2,
        "address": "안양시",
        "products": [
            {
                "product_id": 1,
                "enterprise_id": 1,
                "product_name": "양파",
                "unit": "2kg",
                "product_price": 1
            },
            {
                "product_id": 2,
                "enterprise_id": 1,
                "product_name": "상추",
                "unit": "500g",
                "product_price": 2
            }
        ]
    }
}
```
<img width="833" alt="image" src="https://github.com/user-attachments/assets/013e6e00-ef54-4210-8831-8c1d2e3fd4c7">


