### PR TITLE
페이지네이션을 활용한 카테고리에 해당하는 상점 전체 조회 API

### DIFF
--- a/src/main/java/com/univ/sohwakhaeng/enterprise/Category.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/Category.java
@@ -1,0 +1,25 @@
+package com.univ.sohwakhaeng.enterprise;
+
+public enum Category {
+    AGRICULTURAL_PRODUCTS("농산물"),
+    SEAFOOD("해산물"),
+    MEAT("육류"),
+    BAKERY("베이커리"),
+    DAIRY_AND_EGGS("유제품 및 계란"),
+    FLORICULTURE("화훼");
+
+    private final String description;
+
+    Category(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/Enterprise.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/Enterprise.java
@@ -9,10 +9,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 
 @Entity
 @Getter
@@ -29,6 +32,9 @@ public class Enterprise {
 
     @Column(name = "enterprise_name")
     private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
 
     private String description;
 

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/api/EnterpriseController.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/api/EnterpriseController.java
@@ -1,14 +1,19 @@
 package com.univ.sohwakhaeng.enterprise.api;
 
-import com.univ.sohwakhaeng.enterprise.api.dto.EnterpriseDto;
+import com.univ.sohwakhaeng.enterprise.Category;
+import com.univ.sohwakhaeng.enterprise.api.dto.EnterpriseDetailDto;
+import com.univ.sohwakhaeng.enterprise.api.dto.EnterpriseOverviewDto;
 import com.univ.sohwakhaeng.enterprise.exception.EnterpriseNotFoundException;
 import com.univ.sohwakhaeng.enterprise.service.EnterpriseService;
 import com.univ.sohwakhaeng.global.common.dto.BaseResponse;
+import com.univ.sohwakhaeng.global.common.dto.PagedResponseDto;
 import com.univ.sohwakhaeng.global.common.exception.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,8 +24,18 @@ public class EnterpriseController {
     private final EnterpriseService enterPriseService;
 
     @GetMapping("/api/enterprises/{enterPriseId}")
-    public BaseResponse<EnterpriseDto> getEnterpriseDetails(@PathVariable Long enterPriseId) throws EnterpriseNotFoundException {
+    public BaseResponse<EnterpriseDetailDto> getEnterpriseDetails(@PathVariable Long enterPriseId) throws EnterpriseNotFoundException {
         return BaseResponse.success(
                 SuccessCode.GET_ENTERPRISE_DETAILS, enterPriseService.getEnterpriseDetails(enterPriseId));
+    }
+
+    @GetMapping("/api/enterprises/category/{category}")
+    public BaseResponse<PagedResponseDto<EnterpriseOverviewDto>> getEnterprisesByCategory(
+            @PathVariable Category category,
+            @RequestParam int size,
+            @RequestParam int limit
+    ){
+        return BaseResponse.success(
+                SuccessCode.GET_ENTERPRISE_OVERVIEW, enterPriseService.getEnterprisesByCategory(category, PageRequest.of(size, limit)));
     }
 }

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseDetailDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseDetailDto.java
@@ -6,7 +6,7 @@ import com.univ.sohwakhaeng.enterprise.Enterprise;
 import com.univ.sohwakhaeng.product.api.dto.ProductDto;
 import java.util.List;
 
-public record EnterpriseDto(
+public record EnterpriseDetailDto(
         @JsonProperty("enterprise_id")
         Long id,
 
@@ -38,8 +38,8 @@ public record EnterpriseDto(
         List<ProductDto> products
 ) {
 
-    public static EnterpriseDto fromEntity(Enterprise enterprise) {
-        return new EnterpriseDto(
+    public static EnterpriseDetailDto fromEntity(Enterprise enterprise) {
+        return new EnterpriseDetailDto(
                 enterprise.getId(),
                 enterprise.getImageUrl(),
                 enterprise.getName(),

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseDto.java
@@ -1,6 +1,7 @@
 package com.univ.sohwakhaeng.enterprise.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.univ.sohwakhaeng.enterprise.Category;
 import com.univ.sohwakhaeng.enterprise.Enterprise;
 import com.univ.sohwakhaeng.product.api.dto.ProductDto;
 import java.util.List;
@@ -14,6 +15,9 @@ public record EnterpriseDto(
 
         @JsonProperty("enterprise_name")
         String name,
+
+        @JsonProperty("category")
+        Category category,
 
         @JsonProperty("description")
         String description,
@@ -39,6 +43,7 @@ public record EnterpriseDto(
                 enterprise.getId(),
                 enterprise.getImageUrl(),
                 enterprise.getName(),
+                enterprise.getCategory(),
                 enterprise.getDescription(),
                 enterprise.getStar(),
                 enterprise.getLatitude(),

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseOverviewDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseOverviewDto.java
@@ -1,0 +1,30 @@
+package com.univ.sohwakhaeng.enterprise.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.univ.sohwakhaeng.enterprise.Category;
+import com.univ.sohwakhaeng.enterprise.Enterprise;
+
+public record EnterpriseOverviewDto(
+        @JsonProperty("enterprise_id")
+        Long id,
+
+        @JsonProperty("enterprise_image_url")
+        String imageUrl,
+
+        @JsonProperty("enterprise_name")
+        String name,
+
+        @JsonProperty("category")
+        Category category
+) {
+
+    public static EnterpriseOverviewDto fromEntity(Enterprise enterprise) {
+        return new EnterpriseOverviewDto(
+                enterprise.getId(),
+                enterprise.getImageUrl(),
+                enterprise.getName(),
+                enterprise.getCategory()
+        );
+    }
+
+}

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/repository/EnterpriseRepository.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/repository/EnterpriseRepository.java
@@ -1,7 +1,16 @@
 package com.univ.sohwakhaeng.enterprise.repository;
 
+import com.univ.sohwakhaeng.enterprise.Category;
 import com.univ.sohwakhaeng.enterprise.Enterprise;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 
 public interface EnterpriseRepository extends JpaRepository<Enterprise, Long> {
+
+    @Query("SELECT e FROM Enterprise e WHERE e.category = :category")
+    Page<Enterprise> getPagedEnterprisesByCategory(Category category, Pageable pageable);
+
 }

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/service/EnterpriseService.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/service/EnterpriseService.java
@@ -1,10 +1,15 @@
 package com.univ.sohwakhaeng.enterprise.service;
 
+import com.univ.sohwakhaeng.enterprise.Category;
 import com.univ.sohwakhaeng.enterprise.Enterprise;
-import com.univ.sohwakhaeng.enterprise.api.dto.EnterpriseDto;
+import com.univ.sohwakhaeng.enterprise.api.dto.EnterpriseDetailDto;
+import com.univ.sohwakhaeng.enterprise.api.dto.EnterpriseOverviewDto;
 import com.univ.sohwakhaeng.enterprise.exception.EnterpriseNotFoundException;
 import com.univ.sohwakhaeng.enterprise.repository.EnterpriseRepository;
+import com.univ.sohwakhaeng.global.common.dto.PagedResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,14 +22,25 @@ public class EnterpriseService {
     private final EnterpriseRepository enterpriseRepository;
 
     @Transactional(readOnly = true)
-    public EnterpriseDto getEnterpriseDetails(Long enterpriseId) throws EnterpriseNotFoundException {
+    public EnterpriseDetailDto getEnterpriseDetails(Long enterpriseId) throws EnterpriseNotFoundException {
         Enterprise enterprise = findEnterpriseEntityById(enterpriseId);
-        return EnterpriseDto.fromEntity(enterprise);
+        return EnterpriseDetailDto.fromEntity(enterprise);
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponseDto<EnterpriseOverviewDto> getEnterprisesByCategory(Category category, Pageable pageable) {
+        Page<Enterprise> enterprises = getPagedEnterprisesByCategory(category, pageable);
+        Page<EnterpriseOverviewDto> enterpriseOverviewDtos = enterprises.map(EnterpriseOverviewDto::fromEntity);
+        return new PagedResponseDto<>(enterpriseOverviewDtos);
     }
 
     private Enterprise findEnterpriseEntityById(Long id) throws EnterpriseNotFoundException {
         return enterpriseRepository.findById(id)
                 .orElseThrow(() -> new EnterpriseNotFoundException(ENTERPRISE_NOT_FOUND.getMessage()));
+    }
+
+    private Page<Enterprise> getPagedEnterprisesByCategory(Category category, Pageable pageable) {
+        return enterpriseRepository.getPagedEnterprisesByCategory(category, pageable);
     }
 
 }

--- a/src/main/java/com/univ/sohwakhaeng/global/common/dto/PagedResponseDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/common/dto/PagedResponseDto.java
@@ -1,0 +1,29 @@
+package com.univ.sohwakhaeng.global.common.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+@Setter
+@Getter
+public class PagedResponseDto<T> {
+
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasPrevious;
+    private boolean hasNext;
+
+    public PagedResponseDto(Page<T> page) {
+        this.content = page.getContent();
+        this.page = page.getNumber();
+        this.size = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.hasPrevious = page.hasPrevious();
+        this.hasNext = page.hasNext();
+    }
+}

--- a/src/main/java/com/univ/sohwakhaeng/global/common/exception/SuccessCode.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/common/exception/SuccessCode.java
@@ -23,7 +23,8 @@ public enum SuccessCode {
     GET_MY_POSTS(HttpStatus.OK, "내가 쓴 글 조회 성공"),
 
     // Enterprise 관련
-    GET_ENTERPRISE_DETAILS(HttpStatus.OK, "상점 상세 정보 조회 성공")
+    GET_ENTERPRISE_DETAILS(HttpStatus.OK, "상점 상세 정보 조회 성공"),
+    GET_ENTERPRISE_OVERVIEW(HttpStatus.OK, "상점 기본 정보 조회 성공"),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
# 🔖 개요

이슈번호 #7 
카테고리에 해당하는 상점 전체 페이지네이션 API를 작성했습니다.

# 🖊️ 상세 설명
카테고리를 전달 받으면 해당되는 상점의 기본 정보를 전달합니다.
이때 페이지네이션을 적용해서 스크롤 시 다음 페이지 넘버로 요청해주시면 됩니다.

# 📷 예시 or 스크린샷
postman으로 테스트했습니다.
```
{
    "statusCode": 200,
    "message": "상점 간략 정보 조회 성공",
    "data": {
        "content": [
            {
                "enterprise_id": 2,
                "enterprise_image_url": "ㅁㄴㅇㄻㄴㅇㄹ",
                "enterprise_name": "싱싱수산",
                "category": "SEAFOOD"
            }
        ],
        "page": 0,
        "size": 10,
        "totalElements": 1,
        "totalPages": 1,
        "hasPrevious": false,
        "hasNext": false
    }
}
```
<img width="821" alt="image" src="https://github.com/user-attachments/assets/50f12e53-d881-4f97-8521-948aee18cd60">


