### PR TITLE
Swagger 세팅 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,17 +24,26 @@ repositories {
 }
 
 dependencies {
+    // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Application
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }

--- a/src/main/java/com/univ/sohwakhaeng/global/config/SecurityConfig.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/config/SecurityConfig.java
@@ -29,6 +29,12 @@ public class SecurityConfig extends Exception {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
 
+    private static final String[] ALLOWED_URL = {
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**"
+    };
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -49,6 +55,7 @@ public class SecurityConfig extends Exception {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests((request) -> request
+                        .requestMatchers(ALLOWED_URL).permitAll()
                         .requestMatchers("/api/{provider}/token", "/api/user/logout").permitAll()
                         .requestMatchers("/api/**").authenticated()
                 )

--- a/src/main/java/com/univ/sohwakhaeng/global/config/SecurityConfig.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig extends Exception {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests((request) -> request
-                        .requestMatchers("/**").permitAll()
+                        .requestMatchers("/api/{provider}/token", "/api/user/logout").permitAll()
+                        .requestMatchers("/api/**").authenticated()
                 )
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/univ/sohwakhaeng/global/config/SwaggerConfig.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/config/SwaggerConfig.java
@@ -1,0 +1,46 @@
+package com.univ.sohwakhaeng.global.config;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@SecurityScheme(
+        name = "accessToken",
+        type = SecuritySchemeType.APIKEY,
+        in = SecuritySchemeIn.HEADER,
+        paramName = "Authorization",
+        description = "access token"
+)
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI springBootAPI() {
+        Info info = new Info()
+                .title("소확행")
+                .description("소확행 API 문서")
+                .contact(new Contact().name("전민주").url("https://github.com/mingmingmon").email("mingmingmon@naver.com"));
+
+        Server server = new Server().url("/");
+
+        return new OpenAPI()
+                .servers(List.of(server))
+                .info(info)
+                .security(
+                        List.of(new SecurityRequirement().addList("accessToken"))
+                );
+    }
+}
+


### PR DESCRIPTION
# 🔖 개요

이슈번호 #8
스웨거를 통해서 API 테스트 및 명세서 작성을 자동으로 할 수 있도록 했습니다.

# 🖊️ 상세 설명

스웨거 세팅을 완료하였고, JWT를 사용할 수 있게 해놓았습니다.
접속 url은 `http://localhost:1234/swagger-ui/index.html#/auth-controller/auth` 입니다.
사진속에는 8080으로 접속했는데, 다음 작업한 이슈에서 포트번호를 1234로 명시하도록 했습니다.

# 📷 예시 or 스크린샷
<img width="765" alt="image" src="https://github.com/user-attachments/assets/86fc2f4e-597e-4bed-837c-1616c97832cf">
