### PR TITLE
장바구니 등록 API 작성

### DIFF
--- a/src/main/java/com/univ/sohwakhaeng/auth/domain/PrincipalDetails.java
+++ b/src/main/java/com/univ/sohwakhaeng/auth/domain/PrincipalDetails.java
@@ -70,4 +70,8 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
     public String getName() {
         return user.getUsername();
     }
+
+    public User getUser() {
+        return this.user;
+    }
 }

--- a/src/main/java/com/univ/sohwakhaeng/cart/Cart.java
+++ b/src/main/java/com/univ/sohwakhaeng/cart/Cart.java
@@ -1,7 +1,7 @@
 package com.univ.sohwakhaeng.cart;
 
 import com.univ.sohwakhaeng.enterprise.Enterprise;
-import com.univ.sohwakhaeng.productorder.ProductOrder;
+import com.univ.sohwakhaeng.item.Item;
 import com.univ.sohwakhaeng.user.User;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -15,12 +15,16 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Cart {
 
     @Id
@@ -37,6 +41,16 @@ public class Cart {
     private User user;
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<ProductOrder> productOrders;
+    private List<Item> items;
 
+    public static Cart createCart(Enterprise enterprise, User user) {
+        return Cart.builder()
+                .enterprise(enterprise)
+                .user(user)
+                .build();
+    }
+
+    public void updateItems(List<Item> items) {
+        this.items = items;
+    }
 }

--- a/src/main/java/com/univ/sohwakhaeng/cart/Cart.java
+++ b/src/main/java/com/univ/sohwakhaeng/cart/Cart.java
@@ -1,0 +1,42 @@
+package com.univ.sohwakhaeng.cart;
+
+import com.univ.sohwakhaeng.enterprise.Enterprise;
+import com.univ.sohwakhaeng.productorder.ProductOrder;
+import com.univ.sohwakhaeng.user.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cart {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cart_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "enterprise_id")
+    private Enterprise enterprise;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ProductOrder> productOrders;
+
+}

--- a/src/main/java/com/univ/sohwakhaeng/cart/api/CartController.java
+++ b/src/main/java/com/univ/sohwakhaeng/cart/api/CartController.java
@@ -1,0 +1,33 @@
+package com.univ.sohwakhaeng.cart.api;
+
+import com.univ.sohwakhaeng.auth.domain.PrincipalDetails;
+import com.univ.sohwakhaeng.cart.api.dto.CartRequestDto;
+import com.univ.sohwakhaeng.cart.service.CartService;
+import com.univ.sohwakhaeng.enterprise.exception.EnterpriseNotFoundException;
+import com.univ.sohwakhaeng.global.common.dto.BaseResponse;
+import com.univ.sohwakhaeng.global.common.exception.SuccessCode;
+import com.univ.sohwakhaeng.user.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping("/api/carts")
+    public BaseResponse<Long> saveCart(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody CartRequestDto requestDto) throws EnterpriseNotFoundException {
+        User user = principalDetails.getUser();
+        return BaseResponse.success(SuccessCode.POST_CART, cartService.saveCart(requestDto, user));
+    }
+
+
+}

--- a/src/main/java/com/univ/sohwakhaeng/cart/api/dto/CartRequestDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/cart/api/dto/CartRequestDto.java
@@ -1,0 +1,16 @@
+package com.univ.sohwakhaeng.cart.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.univ.sohwakhaeng.item.api.dto.ItemRequestDto;
+import java.util.List;
+
+public record CartRequestDto(
+        @JsonProperty("enterpriseId")
+        Long enterpriseId,
+
+        @JsonProperty("items")
+        List<ItemRequestDto> products
+) {
+
+}
+

--- a/src/main/java/com/univ/sohwakhaeng/cart/repository/CartRepository.java
+++ b/src/main/java/com/univ/sohwakhaeng/cart/repository/CartRepository.java
@@ -1,0 +1,7 @@
+package com.univ.sohwakhaeng.cart.repository;
+
+import com.univ.sohwakhaeng.cart.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+}

--- a/src/main/java/com/univ/sohwakhaeng/cart/service/CartService.java
+++ b/src/main/java/com/univ/sohwakhaeng/cart/service/CartService.java
@@ -1,0 +1,41 @@
+package com.univ.sohwakhaeng.cart.service;
+
+import com.univ.sohwakhaeng.cart.Cart;
+import com.univ.sohwakhaeng.cart.api.dto.CartRequestDto;
+import com.univ.sohwakhaeng.cart.repository.CartRepository;
+import com.univ.sohwakhaeng.enterprise.Enterprise;
+import com.univ.sohwakhaeng.enterprise.exception.EnterpriseNotFoundException;
+import com.univ.sohwakhaeng.enterprise.service.EnterpriseService;
+import com.univ.sohwakhaeng.item.Item;
+import com.univ.sohwakhaeng.item.api.dto.ItemRequestDto;
+import com.univ.sohwakhaeng.item.service.ItemService;
+import com.univ.sohwakhaeng.user.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final EnterpriseService enterpriseService;
+    private final ItemService itemService;
+
+    @Transactional
+    public Long saveCart(CartRequestDto requestDto, User user) throws EnterpriseNotFoundException {
+        Enterprise enterprise = enterpriseService.getEnterpriseEntityById(requestDto.enterpriseId());
+        List<ItemRequestDto> itemRequestDtoList = requestDto.products();
+        Cart cart = Cart.createCart(enterprise, user);
+
+        List<Item> itemList = itemService.saveItems(itemRequestDtoList, cart);
+        cart.updateItems(itemList);
+        return saveCartEntity(cart);
+    }
+
+    private Long saveCartEntity(Cart cart) {
+        return cartRepository.save(cart).getId();
+    }
+
+}

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/Category.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/Category.java
@@ -1,12 +1,12 @@
 package com.univ.sohwakhaeng.enterprise;
 
 public enum Category {
-    AGRICULTURAL_PRODUCTS("농산물"),
-    SEAFOOD("해산물"),
-    MEAT("육류"),
-    BAKERY("베이커리"),
-    DAIRY_AND_EGGS("유제품 및 계란"),
-    FLORICULTURE("화훼");
+    AGRICULTURAL_PRODUCTS("AGRICULTURAL_PRODUCTS"),
+    SEAFOOD("SEAFOOD"),
+    MEAT("MEAT"),
+    BAKERY("BAKERY"),
+    DAIRY_AND_EGGS("DAIRY_AND_EGGS"),
+    FLORICULTURE("FLORICULTURE");
 
     private final String description;
 

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/api/EnterpriseController.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/api/EnterpriseController.java
@@ -36,6 +36,6 @@ public class EnterpriseController {
             @RequestParam int limit
     ){
         return BaseResponse.success(
-                SuccessCode.GET_ENTERPRISE_OVERVIEW, enterPriseService.getEnterprisesByCategory(category, PageRequest.of(size, limit)));
+                SuccessCode.GET_ENTERPRISE_OVERVIEW, enterPriseService.getEnterprisesByCategory(category, PageRequest.of(limit, size)));
     }
 }

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseDetailDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/api/dto/EnterpriseDetailDto.java
@@ -3,7 +3,7 @@ package com.univ.sohwakhaeng.enterprise.api.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.univ.sohwakhaeng.enterprise.Category;
 import com.univ.sohwakhaeng.enterprise.Enterprise;
-import com.univ.sohwakhaeng.product.api.dto.ProductDto;
+import com.univ.sohwakhaeng.product.api.dto.ProductResponseDto;
 import java.util.List;
 
 public record EnterpriseDetailDto(
@@ -35,7 +35,7 @@ public record EnterpriseDetailDto(
         String address,
 
         @JsonProperty("products")
-        List<ProductDto> products
+        List<ProductResponseDto> products
 ) {
 
     public static EnterpriseDetailDto fromEntity(Enterprise enterprise) {
@@ -50,7 +50,7 @@ public record EnterpriseDetailDto(
                 enterprise.getLongitude(),
                 enterprise.getAddress(),
                 enterprise.getProducts().stream()
-                        .map(ProductDto::fromEntity)
+                        .map(ProductResponseDto::fromEntity)
                         .toList()
         );
     }

--- a/src/main/java/com/univ/sohwakhaeng/enterprise/service/EnterpriseService.java
+++ b/src/main/java/com/univ/sohwakhaeng/enterprise/service/EnterpriseService.java
@@ -34,6 +34,11 @@ public class EnterpriseService {
         return new PagedResponseDto<>(enterpriseOverviewDtos);
     }
 
+    @Transactional(readOnly = true)
+    public Enterprise getEnterpriseEntityById(Long id) throws EnterpriseNotFoundException {
+        return findEnterpriseEntityById(id);
+    }
+
     private Enterprise findEnterpriseEntityById(Long id) throws EnterpriseNotFoundException {
         return enterpriseRepository.findById(id)
                 .orElseThrow(() -> new EnterpriseNotFoundException(ENTERPRISE_NOT_FOUND.getMessage()));

--- a/src/main/java/com/univ/sohwakhaeng/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/common/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
      * */
     USER_NOT_FOUND(HttpStatus.NO_CONTENT, "해당 유저가 존재하지 않습니다"),
     ENTERPRISE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가게가 존재하지 않습니다"),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품이 존재하지 않습니다"),
     /**
      * 500 INTERNAL SERVER ERROR
      */

--- a/src/main/java/com/univ/sohwakhaeng/global/common/exception/SuccessCode.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/common/exception/SuccessCode.java
@@ -25,6 +25,9 @@ public enum SuccessCode {
     // Enterprise 관련
     GET_ENTERPRISE_DETAILS(HttpStatus.OK, "상점 상세 정보 조회 성공"),
     GET_ENTERPRISE_OVERVIEW(HttpStatus.OK, "상점 기본 정보 조회 성공"),
+
+    // Cart 관련
+    POST_CART(HttpStatus.OK, "장바구니 등록 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/univ/sohwakhaeng/item/Item.java
+++ b/src/main/java/com/univ/sohwakhaeng/item/Item.java
@@ -1,4 +1,4 @@
-package com.univ.sohwakhaeng.productorder;
+package com.univ.sohwakhaeng.item;
 
 import com.univ.sohwakhaeng.cart.Cart;
 import com.univ.sohwakhaeng.product.Product;
@@ -10,15 +10,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProductOrder {
+@AllArgsConstructor
+@Builder
+public class Item {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,5 +36,13 @@ public class ProductOrder {
     private Product product;
 
     private Integer quantity;
+
+    public static Item fromDto(Product product, Integer quantity, Cart cart) {
+        return Item.builder()
+                .cart(cart)
+                .product(product)
+                .quantity(quantity)
+                .build();
+    }
 
 }

--- a/src/main/java/com/univ/sohwakhaeng/item/api/dto/ItemRequestDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/item/api/dto/ItemRequestDto.java
@@ -1,0 +1,12 @@
+package com.univ.sohwakhaeng.item.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ItemRequestDto(
+        @JsonProperty("product_id")
+        Long productId,
+
+        @JsonProperty("quantity")
+        int quantity
+) {
+}

--- a/src/main/java/com/univ/sohwakhaeng/item/repository/ItemRepository.java
+++ b/src/main/java/com/univ/sohwakhaeng/item/repository/ItemRepository.java
@@ -1,0 +1,7 @@
+package com.univ.sohwakhaeng.item.repository;
+
+import com.univ.sohwakhaeng.item.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/com/univ/sohwakhaeng/item/service/ItemService.java
+++ b/src/main/java/com/univ/sohwakhaeng/item/service/ItemService.java
@@ -1,0 +1,46 @@
+package com.univ.sohwakhaeng.item.service;
+
+import com.univ.sohwakhaeng.cart.Cart;
+import com.univ.sohwakhaeng.item.Item;
+import com.univ.sohwakhaeng.item.api.dto.ItemRequestDto;
+import com.univ.sohwakhaeng.item.repository.ItemRepository;
+import com.univ.sohwakhaeng.product.Product;
+import com.univ.sohwakhaeng.product.exception.ProductNotFoundException;
+import com.univ.sohwakhaeng.product.service.ProductService;
+import com.univ.sohwakhaeng.user.User;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ItemService {
+
+    private final ItemRepository itemRepository;
+    private final ProductService productService;
+
+    @Transactional
+    public List<Item> saveItems(List<ItemRequestDto> itemRequestDtoList, Cart cart) {
+        List<Item> items = itemRequestDtoList.stream()
+                .map(dto -> {
+                    Product product = null;
+                    try {
+                        product = productService.getProductById(dto.productId());
+                    } catch (ProductNotFoundException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return Item.fromDto(product, dto.quantity(), cart);
+                })
+                .collect(Collectors.toList());
+        items.forEach(this::saveItem);
+
+        return items;
+    }
+
+    private void saveItem(Item item) {
+        itemRepository.save(item);
+    }
+
+}

--- a/src/main/java/com/univ/sohwakhaeng/product/api/dto/ProductResponseDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/product/api/dto/ProductResponseDto.java
@@ -3,7 +3,7 @@ package com.univ.sohwakhaeng.product.api.dto;
 import com.univ.sohwakhaeng.product.Product;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record ProductDto(
+public record ProductResponseDto(
         @JsonProperty("product_id")
         Long id,
 
@@ -20,8 +20,8 @@ public record ProductDto(
         Integer price
 ) {
 
-    public static ProductDto fromEntity(Product product) {
-        return new ProductDto(
+    public static ProductResponseDto fromEntity(Product product) {
+        return new ProductResponseDto(
                 product.getId(),
                 product.getEnterprise() != null ? product.getEnterprise().getId() : null,
                 product.getName(),

--- a/src/main/java/com/univ/sohwakhaeng/product/exception/ProductNotFoundException.java
+++ b/src/main/java/com/univ/sohwakhaeng/product/exception/ProductNotFoundException.java
@@ -1,0 +1,10 @@
+package com.univ.sohwakhaeng.product.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ProductNotFoundException extends Exception {
+    public ProductNotFoundException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/univ/sohwakhaeng/product/repository/ProductRepository.java
+++ b/src/main/java/com/univ/sohwakhaeng/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.univ.sohwakhaeng.product.repository;
+
+import com.univ.sohwakhaeng.product.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/univ/sohwakhaeng/product/service/ProductService.java
+++ b/src/main/java/com/univ/sohwakhaeng/product/service/ProductService.java
@@ -1,0 +1,28 @@
+package com.univ.sohwakhaeng.product.service;
+
+import com.univ.sohwakhaeng.product.Product;
+import com.univ.sohwakhaeng.product.exception.ProductNotFoundException;
+import com.univ.sohwakhaeng.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.univ.sohwakhaeng.global.common.exception.ErrorCode.PRODUCT_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    @Transactional(readOnly = true)
+    public Product getProductById(Long id) throws ProductNotFoundException {
+        return findProductById(id);
+    }
+
+    private Product findProductById(Long id) throws ProductNotFoundException {
+        return productRepository.findById(id)
+                .orElseThrow(() -> new ProductNotFoundException(PRODUCT_NOT_FOUND.getMessage()));
+    }
+
+}

--- a/src/main/java/com/univ/sohwakhaeng/productorder/ProductOrder.java
+++ b/src/main/java/com/univ/sohwakhaeng/productorder/ProductOrder.java
@@ -1,0 +1,37 @@
+package com.univ.sohwakhaeng.productorder;
+
+import com.univ.sohwakhaeng.cart.Cart;
+import com.univ.sohwakhaeng.product.Product;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductOrder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "enterprise_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "cart_id")
+    private Cart cart;
+
+    @OneToOne
+    private Product product;
+
+    private Integer quantity;
+
+}


### PR DESCRIPTION
# 🔖 개요
이슈번호 #12 
장바구니를 등록하는 API를 작성했습니다.

# 🖊️ 상세 설명
장바구니는 상점, 사용자, 상품리스트를 저장해야합니다.
따라서 상품리스트의 경우는 따로 Item이라고 도메인을 만들어 관리하도록 했습니다.

1. 장바구니 등록 시에 같은 상점에 대해 여러 장바구니를 등록하는 것에 대해서 추가적으로 프론트분들과 논의가 필요합니다. 이 부분은 디테일적인 것이라 다른 api 연동이 다 끝나고 고려해도 무관합니다!

2. 장바구니에 담고자 하는 상품이 요청한 상품의 것인지 판단하는 로직이 추가되면 좋을 것 같습니다. 이 또한 다른 api 작성 후에 추가하겠습니다!

# 📷 예시 or 스크린샷
![image](https://github.com/user-attachments/assets/ebe1cd1d-dc9a-4416-a846-7b9464d3ca90)

