### PR TITLE
계약 조회 기능 구현

### DIFF
--- a/src/main/java/com/univ/sohwakhaeng/contract/api/ContractController.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/api/ContractController.java
@@ -1,6 +1,7 @@
 package com.univ.sohwakhaeng.contract.api;
 
 import com.univ.sohwakhaeng.auth.domain.PrincipalDetails;
+import com.univ.sohwakhaeng.contract.api.dto.ContractDetailDto;
 import com.univ.sohwakhaeng.contract.api.dto.ContractReqDto;
 import com.univ.sohwakhaeng.contract.api.dto.ContractsInfoDto;
 import com.univ.sohwakhaeng.contract.service.ContractService;
@@ -31,5 +32,10 @@ public class ContractController {
                                                                          @RequestParam int limit
     ) {
         return BaseResponse.success(SuccessCode.GET_CONTRACTS, contractService.getMyContracts(principal, PageRequest.of(page, limit)));
+    }
+
+    @GetMapping("/contracts/{contractId}")
+    public BaseResponse<ContractDetailDto> getContract(@PathVariable Long contractId) {
+        return BaseResponse.success(SuccessCode.GET_CONTRACTS, contractService.getContractDetail(contractId));
     }
 }

--- a/src/main/java/com/univ/sohwakhaeng/contract/api/ContractController.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/api/ContractController.java
@@ -1,16 +1,16 @@
 package com.univ.sohwakhaeng.contract.api;
 
 import com.univ.sohwakhaeng.auth.domain.PrincipalDetails;
-import com.univ.sohwakhaeng.contract.dto.ContractReqDto;
+import com.univ.sohwakhaeng.contract.api.dto.ContractReqDto;
+import com.univ.sohwakhaeng.contract.api.dto.ContractsInfoDto;
 import com.univ.sohwakhaeng.contract.service.ContractService;
 import com.univ.sohwakhaeng.global.common.dto.BaseResponse;
+import com.univ.sohwakhaeng.global.common.dto.PagedResponseDto;
 import com.univ.sohwakhaeng.global.common.exception.SuccessCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
@@ -23,5 +23,13 @@ public class ContractController {
     public BaseResponse<Void> requestContract(@RequestBody ContractReqDto contractReqDto, @AuthenticationPrincipal PrincipalDetails principal) {
         contractService.acceptContract(contractReqDto, principal);
         return BaseResponse.success(SuccessCode.POST_CONTRACT);
+    }
+
+    @GetMapping("/contracts")
+    public BaseResponse<PagedResponseDto<ContractsInfoDto>> getContracts(@AuthenticationPrincipal PrincipalDetails principal,
+                                                                         @RequestParam int page,
+                                                                         @RequestParam int limit
+    ) {
+        return BaseResponse.success(SuccessCode.GET_CONTRACTS, contractService.getMyContracts(principal, PageRequest.of(page, limit)));
     }
 }

--- a/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractDetailDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractDetailDto.java
@@ -1,0 +1,25 @@
+package com.univ.sohwakhaeng.contract.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ContractDetailDto(
+        @JsonProperty
+        long enterpriseId,
+        @JsonProperty
+        String profileImgUrl,
+        @JsonProperty
+        String enterpriseName,
+        @JsonProperty
+        String category,
+        @JsonProperty
+        String reqularDelivery,
+        @JsonProperty
+        String requestTerm,
+        @JsonProperty
+        List<ContractProducsResDto> products
+) {
+}

--- a/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractProducsResDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractProducsResDto.java
@@ -1,0 +1,13 @@
+package com.univ.sohwakhaeng.contract.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record ContractProducsResDto(
+        @JsonProperty
+        String name,
+        @JsonProperty
+        int quantity
+) {
+}

--- a/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractReqDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractReqDto.java
@@ -1,4 +1,4 @@
-package com.univ.sohwakhaeng.contract.dto;
+package com.univ.sohwakhaeng.contract.api.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractsInfoDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractsInfoDto.java
@@ -1,0 +1,13 @@
+package com.univ.sohwakhaeng.contract.api.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ContractsInfoDto(
+        long enterpriseId,
+        long contractId,
+        String profileImage,
+        String enterpriseName,
+        String category
+) {
+}

--- a/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractsInfoDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ContractsInfoDto.java
@@ -1,13 +1,19 @@
 package com.univ.sohwakhaeng.contract.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
 @Builder
 public record ContractsInfoDto(
+        @JsonProperty
         long enterpriseId,
+        @JsonProperty
         long contractId,
+        @JsonProperty
         String profileImage,
+        @JsonProperty
         String enterpriseName,
+        @JsonProperty
         String category
 ) {
 }

--- a/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ProductDto.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/api/dto/ProductDto.java
@@ -1,4 +1,4 @@
-package com.univ.sohwakhaeng.contract.dto;
+package com.univ.sohwakhaeng.contract.api.dto;
 
 public record ProductDto(
         long productId,

--- a/src/main/java/com/univ/sohwakhaeng/contract/domain/Contract.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/domain/Contract.java
@@ -3,15 +3,13 @@ package com.univ.sohwakhaeng.contract.domain;
 import com.univ.sohwakhaeng.enterprise.Enterprise;
 import com.univ.sohwakhaeng.user.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Contract {

--- a/src/main/java/com/univ/sohwakhaeng/contract/domain/ContractProducts.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/domain/ContractProducts.java
@@ -2,12 +2,10 @@ package com.univ.sohwakhaeng.contract.domain;
 
 import com.univ.sohwakhaeng.product.Product;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
+@Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ContractProducts {

--- a/src/main/java/com/univ/sohwakhaeng/contract/domain/repository/ContractRepository.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/domain/repository/ContractRepository.java
@@ -3,10 +3,16 @@ package com.univ.sohwakhaeng.contract.domain.repository;
 import com.univ.sohwakhaeng.contract.domain.Contract;
 import com.univ.sohwakhaeng.enterprise.Enterprise;
 import com.univ.sohwakhaeng.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface ContractRepository extends JpaRepository<Contract, Long> {
     Optional<Contract> findByUserAndEnterprise(User user, Enterprise enterprise);
+
+    @Query("SELECT c FROM Contract c WHERE c.user = :user")
+    Page<Contract> getPagedContractsByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/univ/sohwakhaeng/contract/service/ContractService.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/service/ContractService.java
@@ -100,6 +100,7 @@ public class ContractService {
                 .profileImgUrl(contract.getEnterprise().getImageUrl())
                 .enterpriseName(contract.getEnterprise().getName())
                 .products(contract.getContractProducts().stream().map(this::convertToDtoFromContractProducts).toList())
+                .category(contract.getEnterprise().getCategory().toString())
                 .build();
     }
 

--- a/src/main/java/com/univ/sohwakhaeng/contract/service/ContractService.java
+++ b/src/main/java/com/univ/sohwakhaeng/contract/service/ContractService.java
@@ -1,19 +1,24 @@
 package com.univ.sohwakhaeng.contract.service;
 
 import com.univ.sohwakhaeng.auth.domain.PrincipalDetails;
+import com.univ.sohwakhaeng.contract.api.dto.ContractReqDto;
+import com.univ.sohwakhaeng.contract.api.dto.ContractsInfoDto;
 import com.univ.sohwakhaeng.contract.domain.Contract;
 import com.univ.sohwakhaeng.contract.domain.ContractProducts;
 import com.univ.sohwakhaeng.contract.domain.MethodToTake;
 import com.univ.sohwakhaeng.contract.domain.repository.ContractProductsRepository;
 import com.univ.sohwakhaeng.contract.domain.repository.ContractRepository;
-import com.univ.sohwakhaeng.contract.dto.ContractReqDto;
 import com.univ.sohwakhaeng.enterprise.Enterprise;
 import com.univ.sohwakhaeng.enterprise.repository.EnterpriseRepository;
+import com.univ.sohwakhaeng.global.common.dto.PagedResponseDto;
 import com.univ.sohwakhaeng.product.Product;
 import com.univ.sohwakhaeng.product.repository.ProductRepository;
 import com.univ.sohwakhaeng.user.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +29,7 @@ public class ContractService {
     private final EnterpriseRepository enterpriseRepository;
     private final ProductRepository productRepository;
 
+    @Transactional
     public void acceptContract(ContractReqDto contractReqDto, PrincipalDetails principal) {
         Contract contract = extractContractEntity(contractReqDto, principal);
         contractReqDto.products().forEach(product -> {
@@ -39,7 +45,8 @@ public class ContractService {
 
     }
 
-    private Contract extractContractEntity(ContractReqDto contractReqDto, PrincipalDetails principal) {
+    @Transactional
+    protected Contract extractContractEntity(ContractReqDto contractReqDto, PrincipalDetails principal) {
         User user = principal.getUser();
         Enterprise enterprise = enterpriseRepository.findById(contractReqDto.enterpriseId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 업체가 존재하지 않습니다."));
@@ -57,5 +64,25 @@ public class ContractService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 계약이 존재하지 않습니다."));
     }
 
+    @Transactional(readOnly = true)
+    public PagedResponseDto<ContractsInfoDto> getMyContracts(PrincipalDetails principal, Pageable pageable) {
+        User user = principal.getUser();
+        Page<Contract> contracts = getPagedContractsByUser(pageable, user);
+        Page<ContractsInfoDto> contractsInfoDtos = contracts.map(this::convertToDtoFromEntity);
+        return new PagedResponseDto<>(contractsInfoDtos);
+    }
 
+    private Page<Contract> getPagedContractsByUser(Pageable pageable, User user) {
+        return contractRepository.getPagedContractsByUser(user, pageable);
+    }
+
+    private ContractsInfoDto convertToDtoFromEntity(Contract contract) {
+        return ContractsInfoDto.builder()
+                .contractId(contract.getId())
+                .enterpriseId(contract.getEnterprise().getId())
+                .enterpriseName(contract.getEnterprise().getName())
+                .category(contract.getEnterprise().getCategory().toString())
+                .profileImage(contract.getEnterprise().getImageUrl())
+                .build();
+    }
 }

--- a/src/main/java/com/univ/sohwakhaeng/global/common/exception/SuccessCode.java
+++ b/src/main/java/com/univ/sohwakhaeng/global/common/exception/SuccessCode.java
@@ -19,7 +19,7 @@ public enum SuccessCode {
     USER_DELETE_SUCCESS(HttpStatus.OK, "회원 탈퇴 완료"),
 
     // Contract 관련
-    POST_CONTRACT(HttpStatus.OK, "계약 등록 성공"),
+    POST_CONTRACT(HttpStatus.CREATED, "계약 등록 성공"),
 
 
     // Enterprise 관련
@@ -27,8 +27,8 @@ public enum SuccessCode {
     GET_ENTERPRISE_OVERVIEW(HttpStatus.OK, "상점 기본 정보 조회 성공"),
 
     // Cart 관련
-    POST_CART(HttpStatus.OK, "장바구니 등록 성공")
-    ;
+    POST_CART(HttpStatus.OK, "장바구니 등록 성공"),
+    GET_CONTRACTS(HttpStatus.OK, "계약 조회 성공"),;
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
# 🔖 개요

이슈번호 #21 

# 🖊️ 설명

사용자가 맺은 전체 계약을 보여주거나 특정 계약의 상세 내용을 보여주는 기능을 구현하였습니다.

# 📷 예시 및 스크린샷

```
{
    "status": 200,
    "message": "계약 상세 조회 정상처리",
    "data": {
        "enterpriseId": 1,
        "profileImgUrl": "이미지 url",
        "enterPriseName": "미미네 채소가게”",
        "category": "농산물",
        "products": [
            {
            "name": "양파 2kg",
            "quantity": 2
            },
            {
            "name": "상추 500g",
            "quantity": 5
            }
        ],
        "regularDelivery": "매주 월, 수",
        "requestTerm": "문 앞에 두고 문자 주세요."
    }
}
```